### PR TITLE
Fixed typo in npm.js

### DIFF
--- a/test/npm.js
+++ b/test/npm.js
@@ -62,7 +62,7 @@ describe('NPM integration', function() {
     });
   });
 
-  it("contract compiliation successfully picks up modules and their dependencies", function(done) {
+  it("contract compilation successfully picks up modules and their dependencies", function(done) {
     this.timeout(10000);
 
     Contracts.compile(config.with({


### PR DESCRIPTION
There was a typo for "compilation" word.